### PR TITLE
Feature/misc fixes

### DIFF
--- a/cdap-stream-clients/python/__init__.py
+++ b/cdap-stream-clients/python/__init__.py
@@ -14,16 +14,3 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-from setuptools import setup
-from setuptools import find_packages
-
-
-setup(name='cdap-stream-client',
-      version='${project.version}',
-      description='Stream ingestion client for Cask Data Application Platform',
-      author='Cask Data',
-      author_email='cask-dev@googlegroups.com',
-      packages=find_packages(),
-      install_requires=['cdap_auth_client'],
-      tests_require=['httpretty', 'mock'],
-      )

--- a/cdap-stream-clients/python/cdap_stream_client/__init__.py
+++ b/cdap-stream-clients/python/cdap_stream_client/__init__.py
@@ -15,4 +15,5 @@
 #  the License.
 
 from streamclient import StreamClient
+from streamwriter import StreamWriter
 from config import Config

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -17,23 +17,19 @@
 from __future__ import with_statement
 import json
 from io import open
-from cdap_auth_client.BasicAuthenticationClient import BasicAuthenticationClient
-from cdap_auth_client.Config import Config as AuthConfig
+from cdap_auth_client import BasicAuthenticationClient
+from cdap_auth_client import Config as AuthConfig
 
 
 class Config(object):
 
     def __init__(self, host=u'localhost', port=10000, ssl=False,
-                 ssl_disable_check=True, filename=u''):
+                 ssl_disable_check=True):
         self.__host = host
         self.__port = port
         self.__ssl = ssl
         self.__ssl_disable_check = ssl_disable_check
-        self.__authClient = BasicAuthenticationClient()
-        self.__authClient.set_connection_info(self.__host,
-                                              self.__port, self.__ssl)
-        if filename:
-            self.__authClient.configure(AuthConfig().read_from_file(filename))
+        self.__authClient = None
 
     def set_auth_client(self, client):
         self.__authClient = client
@@ -72,6 +68,8 @@ class Config(object):
 
     @property
     def auth_token(self):
+        if self.__authClient is None:
+            raise AttributeError("Authentication Client is not set.")
         try:
             return self.__authClient.get_access_token()
         except IOError:
@@ -79,7 +77,7 @@ class Config(object):
 
     @property
     def is_auth_enabled(self):
-        return self.__authClient.is_auth_enabled()
+        return self.__authClient is not None and self.__authClient.is_auth_enabled()
 
     @staticmethod
     def read_from_file(filename):

--- a/cdap-stream-clients/python/setup.py
+++ b/cdap-stream-clients/python/setup.py
@@ -21,7 +21,7 @@ from setuptools import find_packages
 setup(name='cdap-stream-client',
       version='${project.version}',
       description='Stream ingestion client for Cask Data Application Platform',
-      author='Cask Data',
+      author='Cask Data, Inc.',
       author_email='cask-dev@googlegroups.com',
       packages=find_packages(),
       install_requires=['cdap_auth_client'],

--- a/cdap-stream-clients/python/test/runtests.py
+++ b/cdap-stream-clients/python/test/runtests.py
@@ -32,13 +32,12 @@ import inspect
 current_dir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
 parent_dir = os.path.dirname(current_dir)
-src_dir = parent_dir + '/cdap_stream_client'
-sys.path.insert(0, src_dir)
+sys.path.insert(0, parent_dir)
 
-from config import Config
-from serviceconnector import NotFoundError
-from streamwriter import StreamWriter
-from streamclient import StreamClient
+from cdap_stream_client import Config
+from cdap_stream_client.serviceconnector import NotFoundError
+from cdap_stream_client import StreamWriter
+from cdap_stream_client import StreamClient
 
 with mock.patch('__main__.Config.is_auth_enabled',
                         new_callable=mock.PropertyMock) \
@@ -82,7 +81,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
         exit_code = 404
 
         def setUp(self):
-            config = Config.read_from_file(u'default-config.json')
+            config = Config.read_from_file(os.path.join(os.path.dirname(__file__), u"default-config.json"))
 
             self.sc = StreamClient(config)
 

--- a/cdap-stream-clients/python/test/runtests.py
+++ b/cdap-stream-clients/python/test/runtests.py
@@ -34,10 +34,8 @@ current_dir = os.path.dirname(
 parent_dir = os.path.dirname(current_dir)
 sys.path.insert(0, parent_dir)
 
-from cdap_stream_client import Config
+from cdap_stream_client import Config, StreamWriter, StreamClient
 from cdap_stream_client.serviceconnector import NotFoundError
-from cdap_stream_client import StreamWriter
-from cdap_stream_client import StreamClient
 
 with mock.patch('__main__.Config.is_auth_enabled',
                         new_callable=mock.PropertyMock) \

--- a/cdap-stream-clients/python/test/stream_integration_test.py
+++ b/cdap-stream-clients/python/test/stream_integration_test.py
@@ -21,15 +21,14 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest as unittest
-import requests
 
 from stream_test_base import StreamTestBase
-
+import os
 
 class TestStreamClient(unittest.TestCase, StreamTestBase):
 
     def setUp(self):
-        self.config_file = u'cdap_config.json'
+        self.config_file = os.path.join(os.path.dirname(__file__), u"cdap_config.json")
         self.base_set_up()
 
 if u'__main__' == __name__:

--- a/cdap-stream-clients/python/test/stream_integration_test.py
+++ b/cdap-stream-clients/python/test/stream_integration_test.py
@@ -21,9 +21,9 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest as unittest
+import os
 
 from stream_test_base import StreamTestBase
-import os
 
 class TestStreamClient(unittest.TestCase, StreamTestBase):
 

--- a/cdap-stream-clients/python/test/stream_test_base.py
+++ b/cdap-stream-clients/python/test/stream_test_base.py
@@ -24,10 +24,10 @@ currentdir = os.path.dirname(
 parentdir = os.path.dirname(currentdir)
 sys.path.insert(0, parentdir)
 
-from config import Config
-from serviceconnector import NotFoundError
-from streamwriter import StreamWriter
-from streamclient import StreamClient
+from cdap_stream_client import Config
+from cdap_stream_client.serviceconnector import NotFoundError
+from cdap_stream_client import StreamWriter
+from cdap_stream_client import StreamClient
 from cdap_auth_client.BasicAuthenticationClient import BasicAuthenticationClient
 from cdap_auth_client.Config import Config as AuthConfig
 

--- a/cdap-stream-clients/python/test/stream_test_base.py
+++ b/cdap-stream-clients/python/test/stream_test_base.py
@@ -28,8 +28,8 @@ from cdap_stream_client import Config
 from cdap_stream_client.serviceconnector import NotFoundError
 from cdap_stream_client import StreamWriter
 from cdap_stream_client import StreamClient
-from cdap_auth_client.BasicAuthenticationClient import BasicAuthenticationClient
-from cdap_auth_client.Config import Config as AuthConfig
+from cdap_auth_client import BasicAuthenticationClient
+from cdap_auth_client import Config as AuthConfig
 
 # Should be used as parent class for integration tests.
 # In children 'config_file' property has to be set and

--- a/cdap-stream-clients/python/test/stream_test_base.py
+++ b/cdap-stream-clients/python/test/stream_test_base.py
@@ -24,12 +24,9 @@ currentdir = os.path.dirname(
 parentdir = os.path.dirname(currentdir)
 sys.path.insert(0, parentdir)
 
-from cdap_stream_client import Config
+from cdap_stream_client import Config, StreamWriter, StreamClient
 from cdap_stream_client.serviceconnector import NotFoundError
-from cdap_stream_client import StreamWriter
-from cdap_stream_client import StreamClient
-from cdap_auth_client import BasicAuthenticationClient
-from cdap_auth_client import Config as AuthConfig
+from cdap_auth_client import BasicAuthenticationClient, Config as AuthConfig
 
 # Should be used as parent class for integration tests.
 # In children 'config_file' property has to be set and


### PR DESCRIPTION
Make tests be able to run from any directory (by specifying full paths for files).
 Don't have a default authentication client. Rationale: If user wants an authentication client, they should configure an authentication client (set user/password on it) and then set it onto the stream config. (Also to be more consistent with java stream client)
