### PR TITLE
2.5.0-SNAPSHOT no longer exists.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>2.5.0-SNAPSHOT</cdap.version>
+    <cdap.version>2.5.0</cdap.version>
     <cdap.clients.version>1.0.0-SNAPSHOT</cdap.clients.version>
     <guava.version>17.0</guava.version>
     <http.component.version>4.3.1</http.component.version>


### PR DESCRIPTION
So it wasn't building with mvn.
