### PR TITLE
Feature/fix readmes

### DIFF
--- a/cdap-file-drop-zone/README.md
+++ b/cdap-file-drop-zone/README.md
@@ -84,10 +84,12 @@ where they will automatically be ingested by a daemon process.
  ```
  
  Authentication Client configuration parameters:
- 
+
+ ```
  - pipes.<pipe-name>.sink.auth_client - classpath of authentication client class
  - pipes.<pipe-name>.sink.auth_client_properties - path to authentication client properties file
- 
+ ```
+
 ## Authentication Client Example Configuration
  
  ```

--- a/cdap-file-tailer/README.md
+++ b/cdap-file-tailer/README.md
@@ -38,13 +38,15 @@ it sends it to a Stream via the CDAP REST API.
  
  These parameters must be specified:
 
+```
   - pipes=<pipe1-name, pipe2-name, ...>
   - pipes.<pipe1-name>.source.work_dir=<source-work-directory>
   - pipes.<pipe1-name>.source.file_name=<source-file-name>
   - pipes.<pipe1-name>.sink.stream_name=<stream-name>
   - pipes.<pipe1-name>.sink.host=<host-name>
   - pipes.<pipe1-name>.sink.port=<port-number>
- 
+```
+
  Please note that the target file must be accessible to the File Tailer user.
  To check, you can use the more command with the File Tailer user:
  
@@ -119,10 +121,12 @@ it sends it to a Stream via the CDAP REST API.
  ```
  
  Authentication Client configuration parameters:
- 
+
+```
  - pipes.<pipe-name>.sink.auth_client - classpath of authentication client class
  - pipes.<pipe-name>.sink.auth_client_properties - path to authentication client properties file
- 
+```
+
 ## Authentication Client Example Configuration
  
  ```
@@ -137,6 +141,7 @@ it sends it to a Stream via the CDAP REST API.
  
  Description of configuration parameters:
 
+```
  - daemon_dir - the path to directory for storage of File Tailer state and metrics
  - pipes - list of all pipes, comma-separated
  - pipes.<pipe-name>.name - name of the pipe
@@ -161,3 +166,4 @@ it sends it to a Stream via the CDAP REST API.
  - pipes.<pipe-name>.sink.packSize - number of logs sent at a time (default 1)
  - pipes.<pipe-name>.sink.failure_retry_limit - number of attempts to retry sending logs, if an error occurred while reading file data (default value is 0 for unlimited attempts)
  - pipes.<pipe-name>.sink.failure_sleep_interval - interval to sleep if an error occurred while sending the logs (default 60000 ms)
+```

--- a/cdap-stream-clients/python/README.md
+++ b/cdap-stream-clients/python/README.md
@@ -125,5 +125,6 @@ def on_error_response(response):
     parse response
     ...
 
+stream_promise = stream_writer.write("New stream event");
 stream_promise.on_response(on_ok_response, on_error_response)
 ```

--- a/cdap-stream-clients/python/README.md
+++ b/cdap-stream-clients/python/README.md
@@ -1,18 +1,16 @@
-# CDAP Stream Client Python library
-
-Stream Client Python API for managing Streams via external Python applications.
+# CDAP Stream Client
+The Stream Client Python API is for managing Streams from Python applications.
 
 ## Supported Actions
-
-- create a Stream with a specified *stream-id*;
-- update TTL for an existing Stream with a specified *stream-id*;
-- retrieve the current Stream TTL for a specified *stream-id*;
-- truncate an existing Stream (the deletion of all events that were written to the Stream);
-- write an event to an existing Stream specified by *stream-id*;
+ - Create a Stream
+ - Update TTL (time-to-live) for an existing Stream
+ - Retrieve the current Stream TTL
+ - Truncate an existing Stream (the deletion of all events that were written to the Stream)
+ - Write an event to an existing Stream
 
 
 ## Installation
- To install CDAP Authentication Client, run:
+ To install CDAP Stream Client, run:
 ```
     $ python setup.py install
 ```
@@ -28,36 +26,25 @@ Stream Client Python API for managing Streams via external Python applications.
 
 ## Example
 
-Create a ```StreamClient``` instance, specifying the fields 'host' and 'port' of the gateway server. 
+Create a ```StreamClient``` instance, specifying the fields 'host' and 'port' of the gateway server.
+```
+   streamClient = StreamClient()
+```
+
 Optional configurations that can be set (and their default values):
-
-  - ssl: False (use HTTP protocol)
-
+- ssl: False (use HTTP protocol)
+- ssl_cert_check: true (set false to suspend certificate checks to allow self-signed certificates when SSL is true)
+- authClient: null ([Authenticaton Client](https://github.com/caskdata/cdap-clients/tree/develop/cdap-authentication-clients/java)
+ to interact with a secure CDAP instance)
  ```
    config = Config()
    config.host = 'localhost'
    config.port = 10000
-   config.ssl = False
+   config.ssl = True
+   config.set_auth_client(authentication_client)
 
    streamClient = StreamClient(config)
  ```
-
- or using the ```read_from_file``` method of the ```Config``` object:
-
- ```
-   config = Config.read_from_file('/path/to/config.json')
-
-   streamClient = StreamClient(config)
- ```
-
-Config file structure in JSON format:
-```
-{
-    hostname: 'localhost',    - gateway hostname
-    port: 10000,              - gateway port
-    SSL: false                - if SSL is being used
-}
-```
 
  Create a new Stream with the *stream-id* "newStreamName":
 
@@ -65,28 +52,27 @@ Config file structure in JSON format:
    streamClient.create("newStreamName");
  ```
 
- Notes:
-
-  - The *stream-id* can only contain ASCII letters, digits and hyphens.
-  - If the Stream already exists, no error is returned, and the existing Stream remains in place.
+**Notes:**
+ - The *stream-id* should only contain ASCII letters, digits and hyphens.
+ - If the Stream already exists, no error is returned, and the existing Stream remains in place.
 
 
  Update TTL for the Stream "streamName"; ```newTTL``` is a long value:
 
  ```
-   streamClient.set_ttl("streamName", newTTL);
+   stream_client.set_ttl("streamName", newTTL);
  ```
 
  Get the current TTL value for the Stream "streamName":
 
  ```
-   ttl = streamClient.get_ttl("streamName");
+   ttl = stream_client.get_ttl("streamName");
  ```
 
  Create a ```StreamWriter``` instance for writing events to the Stream "streamName":
 
  ```
-   streamWriter = streamClient.create_writer("streamName");
+   stream_writer = stream_client.create_writer("streamName");
  ```
 
  To write new events to the Stream, you can use either of these these methods of the ```StreamWriter``` class:
@@ -98,44 +84,32 @@ Config file structure in JSON format:
  Example:
 
  ```
-   streamPromise = streamWriter.write("New log event");
+   stream_promise = stream_writer.write("New stream event");
  ```
 
  To truncate the Stream *streamName*, use:
 
  ```
-   streamClient.truncate("streamName");
+   stream_client.truncate("streamName");
  ```
 
  ### StreamPromise
  StreamPromise's goal is to implement deferred code execution.
 
-For error handling, create a handler for each case and set it using the ```onResponse``` method.
+For error handling, create a handler for each case and set it using the ```onResponse``` method. The error handling callback function is optional.
 
 Example:
 
 ```
-def onOkHandler(httpResponse):
+def on_ok_response(response):
     ...
     parse response
     ...
 
-def onErrorHandler(httpResponse):
+def on_error_response(response):
     ...
     parse response
     ...
 
-streamPromise.onResponse(onOkResponse, onErrorResponse)
+stream_promise.on_response(on_ok_response, on_error_response)
 ```
-
-It's not required to define an error handler. If you don't specify an error handler, the success handler is used for both success and error conditions.
-
-## Additional Notes
-
- All methods from the ```StreamClient``` and ```StreamWriter``` throw exceptions using response code analysis from the 
- gateway server. These exceptions help determine if the request was processed successfully or not.
-
- In the case of a **200 OK** response, no exception will be thrown; other cases will throw the NoFoundException exception.
-
-```code``` method of the exception class returns HTTP error code.
-```message``` method of the exception class returns text representation of an error.

--- a/cdap-stream-clients/python/README.md
+++ b/cdap-stream-clients/python/README.md
@@ -10,9 +10,18 @@ The Stream Client Python API is for managing Streams from Python applications.
 
 
 ## Installation
- To install CDAP Stream Client, run:
+ To install CDAP Authentication Client, either [download a zip file](https://repository.continuuity.com/content/repositories/public/co/cask/cdap/cdap-python-stream-client/1.0.0/cdap-python-stream-client-1.0.0.zip)
+ ```
+ $ unzip cdap-python-authentication-client-1.0.0.zip
+ $ cd cdap-python-authentication-client-1.0.0
+ $ python setup.py install
+ ```
+ 
+ or [clone the repository](https://github.com/caskdata/cdap-ingest)
 ```
-    $ python setup.py install
+ $ git clone https://github.com/caskdata/cdap-clients.git
+ $ cd cdap-ingest/cdap-stream-clients/python/
+ $ python setup.py install
 ```
 
 ## Usage
@@ -25,10 +34,10 @@ The Stream Client Python API is for managing Streams from Python applications.
 ```
 
 ## Example
-
+#### Create StreamClient
 Create a ```StreamClient``` instance, specifying the fields 'host' and 'port' of the gateway server.
 ```
-   streamClient = StreamClient()
+   stream_client = StreamClient()
 ```
 
 Optional configurations that can be set (and their default values):
@@ -43,58 +52,62 @@ Optional configurations that can be set (and their default values):
    config.ssl = True
    config.set_auth_client(authentication_client)
 
-   streamClient = StreamClient(config)
+   stream_client = StreamClient(config)
  ```
-
- Create a new Stream with the *stream-id* "newStreamName":
+#### Create Stream
+Create a new Stream with the *stream-id* "newStreamName":
 
  ```
-   streamClient.create("newStreamName");
+   stream_client.create("newStreamName");
  ```
 
 **Notes:**
  - The *stream-id* should only contain ASCII letters, digits and hyphens.
  - If the Stream already exists, no error is returned, and the existing Stream remains in place.
 
+#### Create StreamWriter
+Create a ```StreamWriter``` instance for writing events to the Stream "streamName":
 
- Update TTL for the Stream "streamName"; ```newTTL``` is a long value:
+```
+  stream_writer = stream_client.create_writer("streamName");
+```
 
- ```
-   stream_client.set_ttl("streamName", newTTL);
- ```
+#### Write Stream Events
+To write new events to the Stream, use the ```write``` method of the ```StreamWriter``` class:
 
- Get the current TTL value for the Stream "streamName":
+```
+  def write(self, message, charset=None, headers=None)
+```
 
- ```
-   ttl = stream_client.get_ttl("streamName");
- ```
+Example:
 
- Create a ```StreamWriter``` instance for writing events to the Stream "streamName":
+```
+  stream_promise = stream_writer.write("New stream event");
+```
 
- ```
-   stream_writer = stream_client.create_writer("streamName");
- ```
+#### Truncate Stream
+To truncate the Stream *streamName*, use:
 
- To write new events to the Stream, you can use either of these these methods of the ```StreamWriter``` class:
+```
+  stream_client.truncate("streamName");
+```
 
- ```
-   def write(self, message, charset=None, headers=None)
- ```
+#### Update Stream Time-to-Live (TTL)
+Update TTL for the Stream "streamName"; ```newTTL``` is a long value:
 
- Example:
+```
+  stream_client.set_ttl("streamName", newTTL);
+```
 
- ```
-   stream_promise = stream_writer.write("New stream event");
- ```
+#### Get Stream Time-to-Live (TTL)
+Get the current TTL value for the Stream "streamName":
 
- To truncate the Stream *streamName*, use:
+```
+  ttl = stream_client.get_ttl("streamName");
+```
 
- ```
-   stream_client.truncate("streamName");
- ```
-
- ### StreamPromise
- StreamPromise's goal is to implement deferred code execution.
+### StreamPromise
+StreamPromise's goal is to implement deferred code execution.
 
 For error handling, create a handler for each case and set it using the ```onResponse``` method. The error handling callback function is optional.
 

--- a/cdap-stream-clients/python/README.md
+++ b/cdap-stream-clients/python/README.md
@@ -29,8 +29,8 @@ The Stream Client Python API is for managing Streams from Python applications.
  To use the Stream Client Python API, include these imports in your Python script:
 
 ```
-    from cdap_stream_client import Config
-    from cdap_stream_client import StreamClient
+  from cdap_stream_client import Config
+  from cdap_stream_client import StreamClient
 ```
 
 ## Example
@@ -54,6 +54,7 @@ Optional configurations that can be set (and their default values):
 
    stream_client = StreamClient(config)
  ```
+
 #### Create Stream
 Create a new Stream with the *stream-id* "newStreamName":
 


### PR DESCRIPTION
Two overall topics:
1) Tags such as in the statement: "pipes.<pipe1-name>.source.work_dir=<source-work-directory>" were being omitted by Github markdown, so I surrounded those types of statements with triple `.

2) Modify python stream client README to more accurately reflect the java stream client's (https://raw.githubusercontent.com/caskdata/cdap-ingest/release/1.0.0/cdap-stream-clients/java/README.md)
