### PR TITLE
Remove default auth client, make config

### DIFF
--- a/cdap-stream-clients/python/TESTS.md
+++ b/cdap-stream-clients/python/TESTS.md
@@ -17,14 +17,13 @@ In command shell type this:
 ```> python stream_integration_test_ssl.py```
 
 ## To configure tests change these files:
-```config.json```                  - for unit tests.
-```cdap_config.json```             - for integration with Singlenode reactor
-```cdap_ssl_config.json```         - for integration with SSL and Auth enabled reactor
+```cdap_config.json```             - for integration with Standalone CDAP
+```cdap_ssl_config.json```         - for integration with SSL and Auth enabled CDAP
 
 ## More server instances to tests.
-New tests should be derived from *BasicReactor* and *unittest.TestCase* classes.
+New tests should be derived from *StreamTestBase* and *unittest.TestCase* classes.
 The child object should initialize *self.config_file* variable in *setUp* method
-and call *base_set_up* of *BasicReactor* to initialize tests.
+and call *base_set_up* of *StreamTestBase* to initialize tests.
 
 Example:
 
@@ -32,7 +31,7 @@ Example:
 class TestStreamClient(unittest.TestCase, StreamTestBase):
 
     def setUp(self):
-        self.config_file = 'config_reactor.json'
+        self.config_file = 'cdap_config.json'
         self.base_set_up()
 ```
 

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -71,10 +71,7 @@ class Config(object):
     def auth_token(self):
         if self.__authClient is None:
             raise AttributeError("Authentication Client is not set.")
-        try:
-            return self.__authClient.get_access_token()
-        except IOError:
-            return u''
+        return self.__authClient.get_access_token()
 
     @property
     def is_auth_enabled(self):

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -75,17 +75,3 @@ class Config(object):
     @property
     def is_auth_enabled(self):
         return self.__authClient is not None and self.__authClient.is_auth_enabled()
-
-    @staticmethod
-    def read_from_file(filename):
-        with open(filename) as configFile:
-            json_config = json.loads(configFile.read())
-
-        new_config = Config()
-
-        new_config.host = json_config.get(u'hostname', new_config.host)
-        new_config.port = json_config.get(u'port', new_config.port)
-        new_config.ssl = json_config.get(u'SSL', new_config.ssl)
-        new_config.ssl_cert_check = json_config.get(u'security_ssl_cert_check', new_config.ssl_cert_check)
-
-        return new_config

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -25,7 +25,8 @@ DEFAULT_VERIFY_SSL_CERT = True
 
 class Config(object):
 
-    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, ssl=DEFAULT_SSL, verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT):
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, ssl=DEFAULT_SSL,
+                 verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT):
         self.__host = host
         self.__port = port
         self.__ssl = ssl

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -15,13 +15,17 @@
 #  the License.
 
 from __future__ import with_statement
-import json
-from io import open
+
+
+DEFAULT_HOST = u'localhost'
+DEFAULT_PORT = 10000
+DEFAULT_SSL = False
+DEFAULT_VERIFY_SSL_CERT = True
 
 
 class Config(object):
 
-    def __init__(self, host=u'localhost', port=10000, ssl=False, verify_ssl_cert=True):
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, ssl=DEFAULT_SSL, verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT):
         self.__host = host
         self.__port = port
         self.__ssl = ssl

--- a/cdap-stream-clients/python/cdap_stream_client/streamwriter.py
+++ b/cdap-stream-clients/python/cdap_stream_client/streamwriter.py
@@ -30,7 +30,7 @@ class StreamWriter(object):
         serviceConnector -- reference to connection pool to communicate
                             with gateway server.
         uri -- REST URL part to perform request.
-               Example: '/v2/strems/myStream'
+               Example: '/v2/streams/myStream'
         data -- data to proceed by worker thread.  Please read
                 '__workerTarget' documentation.
         """

--- a/cdap-stream-clients/python/test/cdap_config.json
+++ b/cdap-stream-clients/python/test/cdap_config.json
@@ -1,8 +1,4 @@
 {
     "hostname": "localhost",
-    "port": 10000,
-    "SSL": false,
-    "security_auth_client_username": "username",
-    "security_auth_client_password": "password",
-    "security_ssl_cert_check": false
+    "port": 10000
 }

--- a/cdap-stream-clients/python/test/default-config.json
+++ b/cdap-stream-clients/python/test/default-config.json
@@ -1,4 +1,0 @@
-{
-    "hostname": "dummy.host",
-    "port": 65000
-}

--- a/cdap-stream-clients/python/test/default-config.json
+++ b/cdap-stream-clients/python/test/default-config.json
@@ -1,8 +1,4 @@
 {
     "hostname": "dummy.host",
-    "port": 65000,
-    "SSL": false,
-    "security_auth_client_username": "username",
-    "security_auth_client_password": "password",
-    "security_ssl_cert_check": false
+    "port": 65000
 }

--- a/cdap-stream-clients/python/test/runtests.py
+++ b/cdap-stream-clients/python/test/runtests.py
@@ -48,9 +48,6 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
 
     class TestStreamClient(unittest.TestCase):
-
-        # Should be the same as 'hostname' and 'port' fields in 'default-config.json'
-        # file to make tests work right.
         __dummy_host = u'dummy.host'
         __dummy_port = 65000
         __BASE_URL = u'http://{0}:{1}/v2'.format(__dummy_host, __dummy_port)
@@ -82,8 +79,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
         exit_code = 404
 
         def setUp(self):
-            config = Config.read_from_file(u'default-config.json')
-
+            config = Config(self.__dummy_host, self.__dummy_port)
             self.sc = StreamClient(config)
 
         @httpretty.activate

--- a/cdap-stream-clients/python/test/stream_integration_test.py
+++ b/cdap-stream-clients/python/test/stream_integration_test.py
@@ -21,7 +21,6 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest as unittest
-import requests
 
 from stream_test_base import StreamTestBase
 

--- a/cdap-stream-clients/python/test/stream_test_base.py
+++ b/cdap-stream-clients/python/test/stream_test_base.py
@@ -14,11 +14,11 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-import requests
 
+import inspect
+import json
 import os
 import sys
-import inspect
 currentdir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
 parentdir = os.path.dirname(currentdir)
@@ -26,11 +26,12 @@ sys.path.insert(0, parentdir)
 
 from cdap_stream_client import Config, StreamWriter, StreamClient
 from cdap_stream_client.serviceconnector import NotFoundError
-from cdap_auth_client import BasicAuthenticationClient, Config as AuthConfig
+from cdap_auth_client import BasicAuthenticationClient
 
 # Should be used as parent class for integration tests.
 # In children 'config_file' property has to be set and
 # 'base_set_up' method called.
+
 
 class StreamTestBase(object):
 
@@ -54,13 +55,14 @@ class StreamTestBase(object):
         self.__config_file = filename
 
     def base_set_up(self):
-        authConfig = AuthConfig().read_from_file(self.config_file)
+        with open(self.config_file) as config_file:
+            auth_config = json.loads(config_file.read())
         self.config = Config.read_from_file(self.config_file)
 
         authClient = BasicAuthenticationClient()
         authClient.set_connection_info(self.config.host,
                                        self.config.port, self.config.ssl)
-        authClient.configure(authConfig)
+        authClient.configure(auth_config)
 
         self.config.set_auth_client(authClient)
         self.sc = StreamClient(self.config)

--- a/cdap-stream-clients/python/test/stream_test_base.py
+++ b/cdap-stream-clients/python/test/stream_test_base.py
@@ -54,17 +54,31 @@ class StreamTestBase(object):
     def config_file(self, filename):
         self.__config_file = filename
 
+
+    @staticmethod
+    def read_from_file(filename):
+        with open(filename) as configFile:
+            json_config = json.loads(configFile.read())
+
+        new_config = Config()
+        new_config.host = json_config.get(u'hostname', new_config.host)
+        new_config.port = json_config.get(u'port', new_config.port)
+        new_config.ssl = json_config.get(u'SSL', new_config.ssl)
+        new_config.ssl_cert_check = json_config.get(u'security_ssl_cert_check', new_config.ssl_cert_check)
+        return new_config
+
     def base_set_up(self):
         with open(self.config_file) as config_file:
             auth_config = json.loads(config_file.read())
-        self.config = Config.read_from_file(self.config_file)
+        self.config = StreamTestBase.read_from_file(self.config_file)
 
-        authClient = BasicAuthenticationClient()
-        authClient.set_connection_info(self.config.host,
+        auth_client = BasicAuthenticationClient()
+        auth_client.set_connection_info(self.config.host,
                                        self.config.port, self.config.ssl)
-        authClient.configure(auth_config)
+        if auth_client.is_auth_enabled():
+            auth_client.configure(auth_config)
+            self.config.set_auth_client(auth_client)
 
-        self.config.set_auth_client(authClient)
         self.sc = StreamClient(self.config)
 
     def test_reactor_successful_connection(self):


### PR DESCRIPTION
Don't have a default authentication client. Rationale: If user wants an authentication client, they would have to configure an authentication client (set user/password on it) and then set it onto the stream config. (Also to be more consistent with java stream client).

Also make `Config#read_from_file` allow a file that doesn't have all fields (optional fields).

This works with: https://github.com/caskdata/cdap-clients/pull/50.
