### PR TITLE
Check if auth is enabled before trying to load auth client properties.

### DIFF
--- a/cdap-file-tailer/src/main/java/co/cask/cdap/filetailer/config/PipeConfigurationImpl.java
+++ b/cdap-file-tailer/src/main/java/co/cask/cdap/filetailer/config/PipeConfigurationImpl.java
@@ -276,7 +276,7 @@ public class PipeConfigurationImpl implements PipeConfiguration {
         LOG.warn("Can not load Authentication Client properties file {}: {}",
                   authClientPropertiesPath, e.getMessage(), e);
       } catch (IOException e) {
-        LOG.warn("Failed to check if authorization is enabled.");
+        LOG.warn("Failed to check if authorization is enabled.", e);
       }
 
       String apiKey = getProperty(this.key + "apiKey");


### PR DESCRIPTION
Simply makes the following actions conditional upon `isAuthEnabled`:
-reading of auth client properties file
-configuring auth client

Solves the same problem as: https://github.com/caskdata/cdap-ingest/pull/72, but in file-tailer. (https://github.com/caskdata/cdap-ingest/pull/72 resolves the issue in flume).

Just as reference, [here](https://s3.amazonaws.com/uploads.hipchat.com/26476/1011205/PVXeULnifjRyKby/Screen%20Shot%202014-10-09%20at%2011.17.07%20PM.png) is a screenshot of logs, when omitting authclient.properties file, even if authentication is disabled in cdap, which this fix resolves.
