### PR TITLE
In StreamWriter#write, allow empty strings, disallow null strings

### DIFF
--- a/cdap-integration-tests/cdap-file-drop-zone-integration-tests/src/test/java/co/cask/cdap/file/dropzone/FileDropZoneIT.java
+++ b/cdap-integration-tests/cdap-file-drop-zone-integration-tests/src/test/java/co/cask/cdap/file/dropzone/FileDropZoneIT.java
@@ -51,6 +51,14 @@ public class FileDropZoneIT {
   private static final String EVENT = "165.225.156.91 - - [09/Jan/2014:21:28:53 -0400]" +
     " \"GET /index.html HTTP/1.1\" 200 225 \"http://continuuity.com\" \"Mozilla/4.08 [en] (Win98; I ;Nav)\"";
 
+  private static final String MULTILINE_EVENT = String.format("%s\n%s\n%s\n%s\n%s\n%s",
+                                                              "First line of event",
+                                                              "Second line of event",
+                                                              "Third line of event. Next line is empty line",
+                                                              "",
+                                                              "Line after empty line",
+                                                              "Sixth line of event");
+
   private static final AtomicInteger read = new AtomicInteger(0);
   private static final AtomicInteger ingest = new AtomicInteger(0);
 
@@ -91,6 +99,7 @@ public class FileDropZoneIT {
     try {
       writer = new PrintWriter(file);
       writer.println(EVENT);
+      writer.println(MULTILINE_EVENT);
     } catch (IOException ignored) {
     } finally {
       if (writer != null) {

--- a/cdap-stream-clients/java/src/main/java/co/cask/cdap/client/rest/RestStreamWriter.java
+++ b/cdap-stream-clients/java/src/main/java/co/cask/cdap/client/rest/RestStreamWriter.java
@@ -19,21 +19,16 @@ package co.cask.cdap.client.rest;
 import co.cask.cdap.client.StreamWriter;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.MediaType;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
-import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.FileEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -65,7 +60,7 @@ public class RestStreamWriter implements StreamWriter {
   @Override
   public ListenableFuture<Void> write(String str, Charset charset, Map<String, String> headers) throws
     IllegalArgumentException {
-    Preconditions.checkArgument(StringUtils.isNotEmpty(str), "Input string parameter is empty.");
+    Preconditions.checkArgument(str != null, "Input string parameter is null.");
     return write(new ByteArrayEntity(charset != null ? str.getBytes(charset) : str.getBytes()), headers);
   }
 
@@ -76,7 +71,7 @@ public class RestStreamWriter implements StreamWriter {
 
   @Override
   public ListenableFuture<Void> write(ByteBuffer buffer, Map<String, String> headers) throws IllegalArgumentException {
-    Preconditions.checkArgument(buffer != null, "ByteBuffer parameter is empty.");
+    Preconditions.checkArgument(buffer != null, "ByteBuffer parameter is null.");
     HttpEntity content;
     if (buffer.hasArray()) {
       content = new ByteArrayEntity(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());

--- a/cdap-stream-clients/java/src/test/java/co/cask/cdap/client/rest/RestStreamWriterTest.java
+++ b/cdap-stream-clients/java/src/test/java/co/cask/cdap/client/rest/RestStreamWriterTest.java
@@ -22,16 +22,12 @@ import co.cask.cdap.common.http.exception.HttpFailureException;
 import co.cask.cdap.security.authentication.client.AccessToken;
 import co.cask.cdap.security.authentication.client.AuthenticationClient;
 import com.google.common.base.Charsets;
-import com.google.common.net.MediaType;
 import org.apache.commons.lang.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -58,6 +54,18 @@ public class RestStreamWriterTest extends RestTest {
   public void testSuccessStringWrite() throws Exception {
     streamWriter = streamClient.createWriter(TestUtils.SUCCESS_STREAM_NAME + TestUtils.WRITER_TEST_STREAM_NAME_POSTFIX);
     streamWriter.write(RestTest.EXPECTED_WRITER_CONTENT, Charsets.UTF_8).get();
+  }
+
+  @Test
+  public void testEmptyEventWrite() throws Exception {
+    streamWriter = streamClient.createWriter(TestUtils.ALLOW_ANY_EVENT_STREAM);
+    streamWriter.write("", Charsets.UTF_8).get();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullEventWrite() throws Exception {
+    streamWriter = streamClient.createWriter(TestUtils.ALLOW_ANY_EVENT_STREAM);
+    streamWriter.write(null, Charsets.UTF_8).get();
   }
 
   @Test

--- a/cdap-stream-clients/java/src/test/java/co/cask/cdap/client/rest/TestUtils.java
+++ b/cdap-stream-clients/java/src/test/java/co/cask/cdap/client/rest/TestUtils.java
@@ -43,6 +43,7 @@ public final class TestUtils {
   public static final String WRITER_TEST_STREAM_NAME_POSTFIX = "WriterTest";
   public static final String FILE_STREAM_NAME = "file";
   public static final String WITH_CUSTOM_HEADER_STREAM_NAME = "withHeader";
+  public static final String ALLOW_ANY_EVENT_STREAM = "anyEventAllowed";
 
   private TestUtils() {
   }
@@ -64,7 +65,8 @@ public final class TestUtils {
     int code;
     if (StringUtils.isEmpty(streamName)) {
       code = HttpStatus.SC_INTERNAL_SERVER_ERROR;
-    } else if (SUCCESS_STREAM_NAME.equals(streamName) || TestUtils.FILE_STREAM_NAME.equals(streamName)) {
+    } else if (SUCCESS_STREAM_NAME.equals(streamName) || TestUtils.FILE_STREAM_NAME.equals(streamName)
+      || ALLOW_ANY_EVENT_STREAM.equals(streamName)) {
       code = HttpStatus.SC_OK;
     } else if (NOT_FOUND_STREAM_NAME.equals(streamName)) {
       code = HttpStatus.SC_NOT_FOUND;

--- a/cdap-stream-clients/java/src/test/java/co/cask/cdap/client/rest/handlers/StreamHttpRequestHandler.java
+++ b/cdap-stream-clients/java/src/test/java/co/cask/cdap/client/rest/handlers/StreamHttpRequestHandler.java
@@ -74,7 +74,8 @@ public class StreamHttpRequestHandler implements HttpRequestHandler {
         HttpEntity requestEntity = request.getEntity();
         if (requestEntity != null) {
           String content = RestClient.toString(requestEntity);
-          if (StringUtils.isEmpty(content) || !RestTest.EXPECTED_WRITER_CONTENT.equals(content)) {
+          if (!RestTest.EXPECTED_WRITER_CONTENT.equals(content) &&
+            !TestUtils.ALLOW_ANY_EVENT_STREAM.equals(streamName)) {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
           }
         } else {


### PR DESCRIPTION
[CDAP-396](https://issues.cask.co/browse/CDAP-396)
In StreamWriter#write, allow empty strings and disallow null strings.
This allows for file-tailer and file-drop-zone to work with files that have empty lines.

I have verified that empty strings can be sent to cdap streams (it increases the stream's event count by 1, and data storage of the stream remains unchanged). 
