### PR TITLE
[CDAP-2129] port python stream client to v3

### DIFF
--- a/cdap-stream-clients/python/README.rst
+++ b/cdap-stream-clients/python/README.rst
@@ -52,6 +52,7 @@ Optional configurations that can be set (and their default values):
 
 - host: 'localhost'
 - port: 10000
+- namespace: default
 - ssl: False (set true to use HTTPS protocol)
 - ssl_cert_check: True (set False to suspend certificate checks; this allows self-signed
   certificates when SSL is True)
@@ -64,6 +65,7 @@ Example::
   config = Config()
   config.host = 'localhost'
   config.port = 10000
+  config.namespace = example
   config.ssl = True
   config.set_auth_client(authentication_client)
 

--- a/cdap-stream-clients/python/TESTS.md
+++ b/cdap-stream-clients/python/TESTS.md
@@ -37,7 +37,7 @@ class TestStreamClient(unittest.TestCase, StreamTestBase):
 
 ## License and Trademarks
 
-Copyright © 2014 Cask Data, Inc.
+Copyright © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-stream-clients/python/__init__.py
+++ b/cdap-stream-clients/python/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-stream-clients/python/cdap_stream_client/__init__.py
+++ b/cdap-stream-clients/python/cdap_stream_client/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -30,8 +30,8 @@ DEFAULT_VERIFY_SSL_CERT = True
 class Config(object):
 
     def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT,
-                 version=DEFAULT_VERSION, namespace=DEFAULT_NAMESPACE,
-                 ssl=DEFAULT_SSL, verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT):
+                 ssl=DEFAULT_SSL, verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT,
+                 version=DEFAULT_VERSION, namespace=DEFAULT_NAMESPACE):
         self.__host = host
         self.__port = port
         self.__version = version

--- a/cdap-stream-clients/python/cdap_stream_client/config.py
+++ b/cdap-stream-clients/python/cdap_stream_client/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -21,16 +21,21 @@ from io import open
 
 DEFAULT_HOST = u'localhost'
 DEFAULT_PORT = 10000
+DEFAULT_VERSION = u'v3'
+DEFAULT_NAMESPACE = u'default'
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL_CERT = True
 
 
 class Config(object):
 
-    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT, ssl=DEFAULT_SSL,
-                 verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT):
+    def __init__(self, host=DEFAULT_HOST, port=DEFAULT_PORT,
+                 version=DEFAULT_VERSION, namespace=DEFAULT_NAMESPACE,
+                 ssl=DEFAULT_SSL, verify_ssl_cert=DEFAULT_VERIFY_SSL_CERT):
         self.__host = host
         self.__port = port
+        self.__version = version
+        self.__namespace = namespace
         self.__ssl = ssl
         self.__verify_ssl_cert = verify_ssl_cert
         self.__authClient = None
@@ -53,6 +58,22 @@ class Config(object):
     @port.setter
     def port(self, port):
         self.__port = port
+
+    @property
+    def version(self):
+        return self.__version
+
+    @version.setter
+    def version(self, version):
+        self.__version = version
+
+    @property
+    def namespace(self):
+        return self.__namespace
+
+    @namespace.setter
+    def namespace(self, namespace):
+        self.__namespace = namespace
 
     @property
     def ssl(self):

--- a/cdap-stream-clients/python/cdap_stream_client/serviceconnector.py
+++ b/cdap-stream-clients/python/cdap_stream_client/serviceconnector.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -54,7 +54,7 @@ class ServiceConnector(object):
     }
 
     def __init__(self, config=Config()):
-        self.__base_url = u'{0}://{1}:{2}'
+        self.__base_url = u'{0}://{1}:{2}/{3}/namespaces/{4}'
 
         if not isinstance(config, Config):
             raise TypeError(u'parameter should be of type Config')
@@ -69,8 +69,9 @@ class ServiceConnector(object):
         self.__base_url = self.__base_url.format(
             self.__protocol,
             self.__connectionConfig.host,
-            self.__connectionConfig.port
-        )
+            self.__connectionConfig.port,
+            self.__connectionConfig.version,
+            self.__connectionConfig.namespace)
 
     def request(self, method, uri, body=None, headers=None):
         headersToSend = self.__defaultHeaders

--- a/cdap-stream-clients/python/cdap_stream_client/streamclient.py
+++ b/cdap-stream-clients/python/cdap_stream_client/streamclient.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -23,27 +23,22 @@ from .streamwriter import StreamWriter
 
 class StreamClient(ConnectionErrorChecker):
 
-    __GATEWAY_VERSION = u'/v2'
     __REQUEST_PLACEHOLDERS = {
         u'streamid': u'<streamid>'
     }
-    __REQUESTS = {u'streams': __GATEWAY_VERSION + u'/streams'}
+    __REQUESTS = {u'streams': u'/streams'}
     __REQUESTS[u'stream'] = u'{0}/{1}'.format(__REQUESTS[u'streams'],
-                                            __REQUEST_PLACEHOLDERS[u'streamid'])
-    __REQUESTS[u'consumerid'] = u'{0}/{1}'.format(__REQUESTS[u'stream'],
-                                                u'consumer-id')
-    __REQUESTS[u'dequeue'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'dequeue')
-    __REQUESTS[u'config'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'config')
-    __REQUESTS[u'info'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'info')
+                                              __REQUEST_PLACEHOLDERS[u'streamid'])
+    __REQUESTS[u'properties'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'properties')
     __REQUESTS[u'truncate'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'truncate')
 
     def __init__(self, config=Config()):
         self.__serviceConfig = config
         self.__serviceConnector = ServiceConnector(self.__serviceConfig)
 
-    def __prepare_uri(self, requestName, placeholderName=u'streamid', data=u''):
-        return self.__REQUESTS[requestName].replace(
-            self.__REQUEST_PLACEHOLDERS[placeholderName], data)
+    def __prepare_uri(self, requestName, data=u''):
+        return self.__REQUESTS[requestName] \
+            .replace(self.__REQUEST_PLACEHOLDERS[u'streamid'], data)
 
     def create(self, stream):
         u"""
@@ -67,7 +62,7 @@ class StreamClient(ConnectionErrorChecker):
         objectToSend = {
             u'ttl': ttl
         }
-        uri = self.__prepare_uri(u'config', data=stream)
+        uri = self.__prepare_uri(u'properties', data=stream)
         data = json.dumps(objectToSend)
 
         self.check_response_errors(
@@ -84,7 +79,7 @@ class StreamClient(ConnectionErrorChecker):
         Return value:
         Time-To-Live property in seconds
         """
-        uri = self.__prepare_uri(u'info', data=stream)
+        uri = self.__prepare_uri(u'stream', data=stream)
         response = self.check_response_errors(
             self.__serviceConnector.request(u'GET', uri)
         )

--- a/cdap-stream-clients/python/setup.py
+++ b/cdap-stream-clients/python/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,7 @@ from setuptools import find_packages
 
 
 setup(name='cdap-stream-client',
-      version='1.1.0-SNAPSHOT',
+      version='1.3.0-SNAPSHOT',
       description='Stream ingestion client for Cask Data Application Platform',
       author='Cask Data',
       author_email='cask-dev@googlegroups.com',

--- a/cdap-stream-clients/python/test/cdap_config.json
+++ b/cdap-stream-clients/python/test/cdap_config.json
@@ -1,4 +1,5 @@
 {
     "hostname": "localhost",
-    "port": 10000
+    "port": 10000,
+    "namespace": "test"
 }

--- a/cdap-stream-clients/python/test/runtests.py
+++ b/cdap-stream-clients/python/test/runtests.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -47,23 +47,15 @@ with mock.patch('__main__.Config.is_auth_enabled',
     class TestStreamClient(unittest.TestCase):
         __dummy_host = u'dummy.host'
         __dummy_port = 65000
-        __BASE_URL = u'http://{0}:{1}/v2'.format(__dummy_host, __dummy_port)
+        __dummy_namespace = u'dummy'
+        __BASE_URL = u'http://{0}:{1}/v3/namespaces/{2}'.format(__dummy_host, __dummy_port, __dummy_namespace)
         __REQUEST_PLACEHOLDERS = {
             u'streamid': u'<streamid>'
         }
         __REQUESTS = {u'base_stream_path': __BASE_URL + u'/streams'}
-        __REQUESTS[u'stream'] = u'{0}/{1}'.format(
-            __REQUESTS[u'base_stream_path'],
-            __REQUEST_PLACEHOLDERS[u'streamid'])
-        __REQUESTS[u'consumerid'] = u'{0}/{1}'.format(__REQUESTS[u'stream'],
-                                                      u'consumer-id')
-        __REQUESTS[u'dequeue'] = u'{0}/{1}'.format(__REQUESTS[u'stream'],
-                                                   u'dequeue')
-        __REQUESTS[u'config'] = u'{0}/{1}'.format(__REQUESTS[u'stream'],
-                                                  u'config')
-        __REQUESTS[u'info'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'info')
-        __REQUESTS[u'truncate'] = u'{0}/{1}'.format(__REQUESTS[u'stream'],
-                                                    u'truncate')
+        __REQUESTS[u'stream'] = u'{0}/{1}'.format(__REQUESTS[u'base_stream_path'], __REQUEST_PLACEHOLDERS[u'streamid'])
+        __REQUESTS[u'properties'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'properties')
+        __REQUESTS[u'truncate'] = u'{0}/{1}'.format(__REQUESTS[u'stream'], u'truncate')
 
         validStream = u'validStream'
         invalidStream = u'invalidStream'
@@ -76,7 +68,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
         exit_code = 404
 
         def setUp(self):
-            config = Config(self.__dummy_host, self.__dummy_port)
+            config = Config(host=self.__dummy_host, port=self.__dummy_port, namespace=self.__dummy_namespace)
             self.sc = StreamClient(config)
 
         @httpretty.activate
@@ -115,7 +107,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
         @httpretty.activate
         def test_set_ttl_valid_stream(self):
-            url = self.__REQUESTS[u'config'].replace(
+            url = self.__REQUESTS[u'properties'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.validStream
             )
@@ -134,7 +126,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
         @httpretty.activate
         def test_set_ttl_invalid_stream(self):
-            url = self.__REQUESTS[u'config'].replace(
+            url = self.__REQUESTS[u'properties'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.invalidStream
             )
@@ -155,7 +147,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
         @httpretty.activate
         def test_get_ttl_valid_stream(self):
-            url = self.__REQUESTS[u'info'].replace(
+            url = self.__REQUESTS[u'stream'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.validStream
             )
@@ -174,7 +166,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
         @httpretty.activate
         def test_get_ttl_invalid_stream(self):
-            url = self.__REQUESTS[u'info'].replace(
+            url = self.__REQUESTS[u'stream'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.invalidStream
             )
@@ -194,7 +186,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
         @httpretty.activate
         def test_create_writer_successful(self):
-            url = self.__REQUESTS[u'info'].replace(
+            url = self.__REQUESTS[u'stream'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.validStream
             )
@@ -213,7 +205,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
 
         @httpretty.activate
         def test_create_writer_invalid_stream(self):
-            url = self.__REQUESTS[u'info'].replace(
+            url = self.__REQUESTS[u'stream'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.invalidStream
             )
@@ -237,7 +229,7 @@ with mock.patch('__main__.Config.is_auth_enabled',
                 self.validStream
             )
 
-            urlInfo = self.__REQUESTS[u'info'].replace(
+            urlInfo = self.__REQUESTS[u'stream'].replace(
                 self.__REQUEST_PLACEHOLDERS[u'streamid'],
                 self.validStream
             )


### PR DESCRIPTION
- bumps version to 1.3.0 (same as Java stream client)
- adds a namespace to the configuration.
- uses v3 APIs
- removes consumer-id and dequeue as they are not supported in v3
- adapts tests
