### PR TITLE
[CDAP-2128] port ruby stream client to v3

### DIFF
--- a/cdap-stream-clients/java/README.rst
+++ b/cdap-stream-clients/java/README.rst
@@ -104,4 +104,5 @@ Close the Clients
 When you are finished, release all resources by calling these two methods:
 
      streamWriter.close();
-     streamClient.close();  
+     streamClient.close();
+

--- a/cdap-stream-clients/python/README.rst
+++ b/cdap-stream-clients/python/README.rst
@@ -138,3 +138,23 @@ Example::
 
   stream_promise = stream_writer.write("New stream event")
   stream_promise.on_response(on_ok_response, on_error_response)
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/ruby/Gemfile
+++ b/cdap-stream-clients/ruby/Gemfile
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -20,7 +20,6 @@ gem "rake"
 
 gem 'httparty'
 gem 'thread'
-gem 'promise.rb', '~> 0.6.1'
 gem 'pry'
 
 group :test do

--- a/cdap-stream-clients/ruby/README.rst
+++ b/cdap-stream-clients/ruby/README.rst
@@ -42,7 +42,8 @@ You can configure StreamClient settings in your config files, for example::
   # config/stream.yml
   gateway: 'localhost'
   port: 10000
-  api_version: 'v2'
+  api_version: 'v3'
+  namespace: 'example'
   api_key:
   ssl: false
 
@@ -54,6 +55,7 @@ You can configure StreamClient settings in your config files, for example::
   CDAPIngest::Rest.gateway     = config['gateway']
   CDAPIngest::Rest.port        = config['port']
   CDAPIngest::Rest.api_version = config['api_version']
+  CDAPIngest::Rest.namespace   = config['namespace']
   CDAPIngest::Rest.ssl         = config['ssl']
 
 
@@ -164,3 +166,23 @@ To launch integration tests against Standalone CDAP instance with authentication
 and ssl turned on, execute::
 
   rspec --tag type:it-local-auth-ssl
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/ruby/lib/stream-client-ruby.rb
+++ b/cdap-stream-clients/ruby/lib/stream-client-ruby.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,6 @@
 
 require 'httparty'
 require 'thread'
-require 'promise.rb'
 
 module CDAPIngest
   

--- a/cdap-stream-clients/ruby/lib/stream-client-ruby/rest.rb
+++ b/cdap-stream-clients/ruby/lib/stream-client-ruby/rest.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -27,11 +27,12 @@ module CDAPIngest
       attr_accessor :port
       attr_accessor :api_version
       attr_accessor :ssl
+      attr_accessor :namespace
     end
 
     def initialize
       protocol = self.class.ssl ? 'https' : 'http'
-      self.class.base_uri "#{protocol}://#{self.class.gateway}:#{self.class.port}/#{self.class.api_version}/streams"
+      self.class.base_uri "#{protocol}://#{self.class.gateway}:#{self.class.port}/#{self.class.api_version}/namespaces/#{self.class.namespace}/streams"
       @auth_client = nil
     end
 

--- a/cdap-stream-clients/ruby/lib/stream-client-ruby/stream_client.rb
+++ b/cdap-stream-clients/ruby/lib/stream-client-ruby/stream_client.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -41,7 +41,7 @@ module CDAPIngest
       # @param ttl TTL in seconds
       # @throws NotFoundException If the stream does not exists
     def set_ttl(stream, ttl)
-      rest.request 'put', "#{stream}/config", body: { ttl: ttl }
+      rest.request 'put', "#{stream}/properties", body: { ttl: ttl }
     end
 
     ###
@@ -51,7 +51,7 @@ module CDAPIngest
       # @return Current TTL of the stream in seconds
       # @throws NotFoundException If the stream does not exists
     def get_ttl(stream)
-      response = rest.request 'get', "#{stream}/info"
+      response = rest.request 'get', "#{stream}"
       response['ttl']
     end
 

--- a/cdap-stream-clients/ruby/lib/stream-client-ruby/version.rb
+++ b/cdap-stream-clients/ruby/lib/stream-client-ruby/version.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -13,5 +13,5 @@
 #  the License.
 
 module CDAPIngest
-  VERSION = "1.1.0"
+  VERSION = "1.3.0"
 end

--- a/cdap-stream-clients/ruby/lib/stream-client-ruby/version.rb
+++ b/cdap-stream-clients/ruby/lib/stream-client-ruby/version.rb
@@ -13,5 +13,5 @@
 #  the License.
 
 module CDAPIngest
-  VERSION = "1.3.0"
+  VERSION = '1.3.0'
 end

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/no_stream_client_get_ttl.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/no_stream_client_get_ttl.yml
@@ -1,0 +1,24 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:10000/v3/namespaces/test/streams/non_existing_stream
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Apr 2015 22:39:45 GMT
+recorded_with: VCR 2.9.3

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/no_stream_client_truncate.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/no_stream_client_truncate.yml
@@ -1,0 +1,26 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:10000/v3/namespaces/test/streams/non_existing_stream/truncate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '22'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: Stream does not exists
+    http_version: 
+  recorded_at: Tue, 21 Apr 2015 22:46:59 GMT
+recorded_with: VCR 2.9.3

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/rest_request_get.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/rest_request_get.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:10000/v2/streams/text/info
+    uri: http://localhost:10000/v3/namespaces/test/streams/text
     body:
       encoding: US-ASCII
       string: ''
@@ -20,7 +20,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"partitionDuration":3600000,"indexInterval":10000,"ttl":256000}'
+      string: '{"ttl":9223372036854775}'
     http_version: 
   recorded_at: Mon, 01 Sep 2014 10:54:05 GMT
 recorded_with: VCR 2.9.2

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_create.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_create.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://localhost:10000/v2/streams/rspec_text
+    uri: http://localhost:10000/v3/namespaces/test/streams/rspec_text
     body:
       encoding: US-ASCII
       string: ''

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_get_ttl.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_get_ttl.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:10000/v2/streams/rspec_text/info
+    uri: http://localhost:10000/v3/namespaces/test/streams/rspec_text
     body:
       encoding: US-ASCII
       string: ''

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_set_ttl.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_set_ttl.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://localhost:10000/v2/streams/rspec_text/config
+    uri: http://localhost:10000/v3/namespaces/test/streams/rspec_text/properties
     body:
       encoding: UTF-8
       string: '{"ttl":22500}'
@@ -21,4 +21,27 @@ http_interactions:
       string: ''
     http_version: 
   recorded_at: Mon, 01 Sep 2014 10:54:49 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: http://localhost:10000/v3/namespaces/test/streams/text
+    body:
+      encoding: ASCII-8BIT
+      string: test_body
+    headers: {}
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '22'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: Stream does not exists
+    http_version: 
+  recorded_at: Tue, 21 Apr 2015 23:37:07 GMT
+recorded_with: VCR 2.9.3

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_truncate.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_client_truncate.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:10000/v2/streams/rspec_text/truncate
+    uri: http://localhost:10000/v3/namespaces/test/streams/rspec_text/truncate
     body:
       encoding: US-ASCII
       string: ''

--- a/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_writer_write.yml
+++ b/cdap-stream-clients/ruby/spec/fixtures/vcr_cassettes/stream_writer_write.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://localhost:10000/v2/streams/text
+    uri: http://localhost:10000/v3/namespaces/test/streams/text
     body:
       encoding: ASCII-8BIT
       string: test_body

--- a/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/integration_tests_spec.rb
+++ b/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/integration_tests_spec.rb
@@ -1,3 +1,17 @@
+#  Copyright 2014-2015 Cask Data, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
 require 'spec_helper'
 require 'cdap-authentication-client'
 require 'stream-client-ruby'

--- a/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/rest_spec.rb
+++ b/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/rest_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -33,7 +33,7 @@ describe CDAPIngest::Rest do
 
   it {
     VCR.use_cassette('rest_request_get') {
-      result = rest.request 'get', "text/info"
+      result = rest.request 'get', "text"
       expect(result.class).to eq HTTParty::Response
     }
   }

--- a/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/stream_client_spec.rb
+++ b/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/stream_client_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -55,10 +55,11 @@ describe CDAPIngest::StreamClient do
     }
   }
 
-  xit {
+  it {
     VCR.use_cassette('no_stream_client_get_ttl') {
-      result = stream_client.get_ttl non_existing_stream
-      expect(result).to raise "The request did not address any of the known URIs"
+      expect {
+        result = stream_client.get_ttl non_existing_stream
+      }.to raise_error 'The request did not address any of the known URIs'
     }
   }
 
@@ -71,10 +72,11 @@ describe CDAPIngest::StreamClient do
     }
   }
 
-  xit {
+  it {
     VCR.use_cassette('no_stream_client_truncate') {
-      result = stream_client.truncate non_existing_stream
-      expect(result).to raise "The request did not address any of the known URIs"
+      expect {
+        result = stream_client.truncate non_existing_stream
+      }.to raise_error 'The request did not address any of the known URIs'
     }
   }
 

--- a/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/stream_writer_spec.rb
+++ b/cdap-stream-clients/ruby/spec/lib/stream-client-ruby/stream_writer_spec.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -32,17 +32,10 @@ describe CDAPIngest::StreamWriter do
   it {
     VCR.use_cassette('stream_writer_write') {
       result = stream_writer.write "test_body"
-      expect(result).to be_a Promise
+      expect(result).to be_a Thread::Future
     }
   }
 
   it { expect(stream_writer).to respond_to(:close) }
-
-  it {
-    VCR.use_cassette('stream_writer_close') {
-      result = stream_writer.close
-      expect(result).to be_a Thread::Pool
-    }
-  }
 
 end

--- a/cdap-stream-clients/ruby/spec/reactor.yml
+++ b/cdap-stream-clients/ruby/spec/reactor.yml
@@ -1,4 +1,5 @@
 gateway: 'localhost'
 port: 10000
-api_version: 'v2'
+api_version: 'v3'
+namespace: 'test'
 ssl: false

--- a/cdap-stream-clients/ruby/spec/reactor_ssh.yml
+++ b/cdap-stream-clients/ruby/spec/reactor_ssh.yml
@@ -1,4 +1,5 @@
 gateway: 'localhost'
 port: 10000
-api_version: 'v2'
+api_version: 'v3'
+namespace: 'test'
 ssl: true

--- a/cdap-stream-clients/ruby/spec/stream.yml
+++ b/cdap-stream-clients/ruby/spec/stream.yml
@@ -1,5 +1,6 @@
 gateway: 'localhost'
 port: 10000
-api_version: 'v2'
+api_version: 'v3'
+namespace: 'test'
 api_key:
 ssl: false

--- a/cdap-stream-clients/ruby/spec/support/config.rb
+++ b/cdap-stream-clients/ruby/spec/support/config.rb
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -19,4 +19,5 @@ config = YAML.load_file("spec/stream.yml")
 CDAPIngest::Rest.gateway     = config['gateway']
 CDAPIngest::Rest.port        = config['port']
 CDAPIngest::Rest.api_version = config['api_version']
+CDAPIngest::Rest.namespace   = config['namespace']
 CDAPIngest::Rest.ssl         = config['ssl']

--- a/cdap-stream-clients/ruby/stream-client-ruby.gemspec
+++ b/cdap-stream-clients/ruby/stream-client-ruby.gemspec
@@ -1,4 +1,4 @@
-#  Copyright 2014 Cask Data, Inc.
+#  Copyright 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty'
   s.add_dependency 'thread'
-  s.add_dependency 'promise.rb'
   s.add_dependency 'em-http-request'
 
   s.add_development_dependency 'pry'


### PR DESCRIPTION
- adds namespace to the config, switches to v3 of the API
- fixes existing tests
- fixes problem with stream-writer (existing code actually was not working, failed on develop, too)
- adds copyright to a bunch of README's
