### PR TITLE
Cleanup READMEs for CDAP 3.0 release

### DIFF
--- a/cdap-file-drop-zone/README.rst
+++ b/cdap-file-drop-zone/README.rst
@@ -131,3 +131,23 @@ using 2 pipes::
   pipes.pipe1.sink.verify.ssl.cert=true
   # Path to authentication client properties to use if SSL is being used
   pipes.pipe1.sink.auth_client_properties=/etc/file-drop-zone/conf/auth-client.properties
+  
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-file-drop-zone/README.rst
+++ b/cdap-file-drop-zone/README.rst
@@ -74,7 +74,7 @@ To upload a file that is outside of the *work_dir*, execute the command::
 
   file-drop-zone load <file-path> <observer>
 
-If only one observer is configured, the *observer* parameter is not required::
+If only one observer is configured, the ``<observer>`` parameter is not required::
 
   file-drop-zone load <file-path>
 

--- a/cdap-file-drop-zone/README.rst
+++ b/cdap-file-drop-zone/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ==================
 CDAP File DropZone
 ==================
@@ -131,23 +136,3 @@ using 2 pipes::
   pipes.pipe1.sink.verify.ssl.cert=true
   # Path to authentication client properties to use if SSL is being used
   pipes.pipe1.sink.auth_client_properties=/etc/file-drop-zone/conf/auth-client.properties
-  
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-file-drop-zone/README.rst
+++ b/cdap-file-drop-zone/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ==================

--- a/cdap-file-tailer/README.rst
+++ b/cdap-file-tailer/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ================

--- a/cdap-file-tailer/README.rst
+++ b/cdap-file-tailer/README.rst
@@ -190,3 +190,22 @@ Additional Notes
        data (default value is 0 for unlimited attempts)
    * - ``pipes.<pipe-name>.sink.failure_sleep_interval``
      - Interval to sleep if an error occurred while sending the logs (default 60000 ms)
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-file-tailer/README.rst
+++ b/cdap-file-tailer/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ================
 CDAP File Tailer
 ================
@@ -190,22 +195,3 @@ Additional Notes
        data (default value is 0 for unlimited attempts)
    * - ``pipes.<pipe-name>.sink.failure_sleep_interval``
      - Interval to sleep if an error occurred while sending the logs (default 60000 ms)
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-flume/README.rst
+++ b/cdap-flume/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ==========

--- a/cdap-flume/README.rst
+++ b/cdap-flume/README.rst
@@ -22,13 +22,13 @@ Specify the fully-qualified name of your CDAP Sink class in the Flume configurat
 
   a1.sinks.sink1.type = co.cask.cdap.flume.StreamSink
 
-Enter the host name that is used by the Stream Client::
+Enter the ``host`` name or host-ip that is used by the Stream Client::
 
-  a1.sinks.sink1.host = <hostname or host ip>  
+  a1.sinks.sink1.host = <hostname | host-ip>  
 
 Set the target Stream name::
 
-  a1.sinks.sink1.streamName = <Stream name>
+  a1.sinks.sink1.streamName = <stream-name>
 
 Optional parameters that can be specified are listed below, with their default values.
 

--- a/cdap-flume/README.rst
+++ b/cdap-flume/README.rst
@@ -2,13 +2,13 @@
 CDAP Flume
 ==========
 
-The CDAP Sink is a Flume Sink implementation using REST Stream interface to write events
+The CDAP Sink is a Flume Sink implementation using the CDAP RESTful Stream interface to write events
 received from a source.
 
 Usage
 =====
 
-To use, put the CDAP Sink jar file in the Flume classpath (for example, in the Flume lib
+To use, put the CDAP Sink jar file in the Flume classpath (for example, in the Flume ``lib``
 directory). The JAR can be obtained from `Maven Central
 <http://search.maven.org/#search|ga|1|cdap-flume>`__.
  
@@ -16,7 +16,7 @@ Specify the fully-qualified name of your CDAP Sink class in the Flume configurat
 
   a1.sinks.sink1.type = co.cask.cdap.flume.StreamSink
 
-Enter the host name that is used by the stream client::
+Enter the host name that is used by the Stream Client::
 
   a1.sinks.sink1.host = <hostname or host ip>  
 
@@ -46,7 +46,12 @@ Optional parameters that can be specified are listed below, with their default v
 
 - CDAP Router server version::
 
-    a1.sinks.sink1.version = v2
+    a1.sinks.sink1.version = v3
+    
+- CDAP Namespace::
+
+    a1.sinks.sink1.namespace = default
+
 
 
 Authentication Client
@@ -59,7 +64,7 @@ Fully qualified class name of the client class::
 
   a1.sinks.sink1.authClientClass = co.cask.cdap.security.authentication.client.basic.BasicAuthenticationClient
 
-Path to authentication client properties file::
+Path to the authentication client properties file::
 
   a1.sinks.sink1.authClientProperties = /usr/local/apache-flume/conf/auth_client.conf    
      
@@ -92,3 +97,22 @@ Configuration of a Flume agent that reads data from a log file and puts it to CD
   a1.channels.c1.type = memory
   a1.channels.c1.capacity = 1000
   a1.channels.c1.transactionCapacity = 100
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-flume/README.rst
+++ b/cdap-flume/README.rst
@@ -1,9 +1,15 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ==========
 CDAP Flume
 ==========
 
 The CDAP Sink is a Flume Sink implementation using the CDAP RESTful Stream interface to write events
 received from a source.
+
 
 Usage
 =====
@@ -53,7 +59,6 @@ Optional parameters that can be specified are listed below, with their default v
     a1.sinks.sink1.namespace = default
 
 
-
 Authentication Client
 =====================
 
@@ -97,22 +102,3 @@ Configuration of a Flume agent that reads data from a log file and puts it to CD
   a1.channels.c1.type = memory
   a1.channels.c1.capacity = 1000
   a1.channels.c1.transactionCapacity = 100
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/README.rst
+++ b/cdap-integration-tests/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ==============================================================

--- a/cdap-integration-tests/README.rst
+++ b/cdap-integration-tests/README.rst
@@ -51,3 +51,23 @@ To launch integration tests against Distributed CDAP instance with authenticatio
 and ssl turned on, execute::
 
   mvn clean install -P it-remote-auth-ssl
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/README.rst
+++ b/cdap-integration-tests/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ==============================================================
 Cask Data Application Platform (CDAP) Ingest Integration Tests
 ==============================================================
@@ -51,23 +56,3 @@ To launch integration tests against Distributed CDAP instance with authenticatio
 and ssl turned on, execute::
 
   mvn clean install -P it-remote-auth-ssl
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-file-drop-zone-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-file-drop-zone-integration-tests/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 =====================================================================

--- a/cdap-integration-tests/cdap-file-drop-zone-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-file-drop-zone-integration-tests/README.rst
@@ -42,3 +42,23 @@ enabled, edit::
 
 Please refer to *CDAP File DropZone* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-file-drop-zone-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-file-drop-zone-integration-tests/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 =====================================================================
 Cask Data Application Platform (CDAP) File DropZone Integration Tests
 =====================================================================
@@ -42,23 +47,3 @@ enabled, edit::
 
 Please refer to *CDAP File DropZone* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-file-tailer-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-file-tailer-integration-tests/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ===================================================================

--- a/cdap-integration-tests/cdap-file-tailer-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-file-tailer-integration-tests/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ===================================================================
 Cask Data Application Platform (CDAP) File Tailer Integration Tests
 ===================================================================
@@ -54,23 +59,3 @@ enabled and ssl turned on, edit::
 
 Please refer to *CDAP File Tailer* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-file-tailer-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-file-tailer-integration-tests/README.rst
@@ -54,3 +54,23 @@ enabled and ssl turned on, edit::
 
 Please refer to *CDAP File Tailer* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-flume-java-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-flume-java-integration-tests/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ==================================================================
 Cask Data Application Platform (CDAP) Flume Sink Integration Tests
 ==================================================================
@@ -49,23 +54,3 @@ enabled and ssl turned on, edit::
 
 Please refer to *CDAP Flume Sink* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-flume-java-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-flume-java-integration-tests/README.rst
@@ -49,3 +49,23 @@ enabled and ssl turned on, edit::
 
 Please refer to *CDAP Flume Sink* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-flume-java-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-flume-java-integration-tests/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ==================================================================

--- a/cdap-integration-tests/cdap-stream-client-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-stream-client-integration-tests/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 =====================================================================
 Cask Data Application Platform (CDAP) Stream Client Integration Tests
 =====================================================================
@@ -38,23 +43,3 @@ enabled, edit::
 
 Please refer to *CDAP Java Stream Client* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the 
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
-either express or implied. See the License for the specific language governing permissions 
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-stream-client-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-stream-client-integration-tests/README.rst
@@ -38,3 +38,23 @@ enabled, edit::
 
 Please refer to *CDAP Java Stream Client* in the `CDAP documentation
 <http://docs.cask.co/cdap/current/>`__ for additional information.
+
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the 
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific language governing permissions 
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-integration-tests/cdap-stream-client-integration-tests/README.rst
+++ b/cdap-integration-tests/cdap-stream-client-integration-tests/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 =====================================================================

--- a/cdap-stream-clients/java/README.rst
+++ b/cdap-stream-clients/java/README.rst
@@ -44,11 +44,11 @@ Create a StreamClient instance, specifying the fields 'host' and 'port' of the C
 
 Optional configurations that can be set (and their default values):
 
-- ssl: false (set true to use HTTPS protocol)
-- verifySSLCert: true (set false to suspend certificate checks; this allows self-signed
-  certificates when SSL is true)
-- authClient: null (`CDAP Authentication Client
-  <https://github.com/caskdata/cdap-clients/tree/develop/cdap-authentication-clients/java>`__)
+- ``ssl``: ``false`` (set to ``true`` to use HTTPS protocol)
+- ``verifySSLCert``: ``true`` (set to ``false`` to suspend certificate checks; this allows self-signed
+  certificates to be used when SSL is ``true``)
+- ``authClient``: ``null`` (`CDAP Authentication Client
+  <https://github.com/caskdata/cdap-clients/tree/develop/cdap-authentication-clients/java>`__
   to interact with a secure CDAP instance)
 
 Example::
@@ -60,7 +60,7 @@ Example::
 
 Creating a Stream
 -----------------
-Create a new Stream with the *stream id* "streamName"::
+Create a new Stream with the *stream-id* "streamName"::
 
     streamClient.create("streamName");
 
@@ -101,8 +101,26 @@ Get the current TTL value for the Stream *streamName*::
 
 Close the Clients
 -----------------
-When you are finished, release all resources by calling these two methods:
+When you are finished, release all resources by calling these two methods::
 
      streamWriter.close();
      streamClient.close();
 
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/java/README.rst
+++ b/cdap-stream-clients/java/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ===========================
 CDAP Stream Client for Java
 ===========================
@@ -105,22 +110,3 @@ When you are finished, release all resources by calling these two methods::
 
      streamWriter.close();
      streamClient.close();
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/java/README.rst
+++ b/cdap-stream-clients/java/README.rst
@@ -43,7 +43,7 @@ Examples
 
 Creating a StreamClient
 -----------------------
-Create a StreamClient instance, specifying the fields 'host' and 'port' of the CDAP instance::
+Create a StreamClient instance, specifying the fields ``host`` and ``port`` of the CDAP instance::
 
     StreamClient streamClient = new RestStreamClient.Builder("localhost", 10000).build();
 
@@ -65,13 +65,13 @@ Example::
 
 Creating a Stream
 -----------------
-Create a new Stream with the *stream-id* "streamName"::
+Create a new Stream with the ``<stream-id>`` *streamName*::
 
     streamClient.create("streamName");
 
 **Notes:**
 
-- The *stream-id* should only contain ASCII letters, digits and hyphens.
+- The ``<stream-id>`` should only contain ASCII letters, digits and hyphens.
 - If the Stream already exists, no error is returned, and the existing Stream remains in place.
 
 Creating a StreamWriter

--- a/cdap-stream-clients/java/README.rst
+++ b/cdap-stream-clients/java/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ===========================

--- a/cdap-stream-clients/javascript/README.rst
+++ b/cdap-stream-clients/javascript/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 =================================

--- a/cdap-stream-clients/javascript/README.rst
+++ b/cdap-stream-clients/javascript/README.rst
@@ -149,3 +149,22 @@ errors help determine if the request was processed successfully or not.
 
 In the case of a **200 OK** response, no error will be thrown; in other cases, HTTP status
 code will be returned.
+
+License and Trademarks
+----------------------
+Copyright © 2014-2015 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
+permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/javascript/README.rst
+++ b/cdap-stream-clients/javascript/README.rst
@@ -61,15 +61,15 @@ server. Optional configurations that can be set (and their default values):
    var streamClient = new StreamClient(config)
 
 
-Create a new Stream with the *stream-id* "newStreamName"::
+Create a new Stream with the ``<stream-id>`` *newStreamName*::
 
   streamClient.create("newStreamName");
 
 **Notes:**
-- The *stream-id* can only contain ASCII letters, digits and hyphens.
+- The ``<stream-id>`` can only contain ASCII letters, digits and hyphens.
 - If the Stream already exists, no error is returned, and the existing Stream remains in place.
 
-Update TTL for the Stream "streamName"; ``newTTL`` is a long value::
+Update TTL for the Stream *streamName*; ``newTTL`` is a long value::
 
    var ttlPromise = streamClient.setTTL("streamName", newTTL);
    ttlPromise.then(function onOk(ttlValue) {
@@ -79,7 +79,7 @@ Update TTL for the Stream "streamName"; ``newTTL`` is a long value::
    });
 
 
-Get the current TTL value for the Stream "streamName"::
+Get the current TTL value for the Stream *streamName*::
 
    var ttlPromise = streamClient.getTTL("streamName");
    ttlPromise.then(function onOk(ttlValue) {
@@ -89,7 +89,7 @@ Get the current TTL value for the Stream "streamName"::
    });
 
 
-Create a ``StreamWriter`` instance for writing events to the Stream "streamName"::
+Create a ``StreamWriter`` instance for writing events to the Stream *streamName*::
 
    var streamWriterPromise = streamClient.createWriter("streamName");
    streamWriterPromise.then(function(writer){
@@ -124,7 +124,7 @@ To truncate the Stream *streamName*, use::
 StreamPromise
 -------------
  
-StreamPromise's goal is to implement deferred code execution.
+``StreamPromise``\ 's goal is to implement deferred code execution.
 
 For error handling, create a handler for each case and set it using the ``then`` method.
 

--- a/cdap-stream-clients/javascript/README.rst
+++ b/cdap-stream-clients/javascript/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 =================================
 CDAP Stream Client for JavaScript
 =================================
@@ -149,22 +154,3 @@ errors help determine if the request was processed successfully or not.
 
 In the case of a **200 OK** response, no error will be thrown; in other cases, HTTP status
 code will be returned.
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/python/README.rst
+++ b/cdap-stream-clients/python/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 =============================

--- a/cdap-stream-clients/python/README.rst
+++ b/cdap-stream-clients/python/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 =============================
 CDAP Stream Client for Python
 =============================
@@ -138,23 +143,3 @@ Example::
 
   stream_promise = stream_writer.write("New stream event")
   stream_promise.on_response(on_ok_response, on_error_response)
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/python/README.rst
+++ b/cdap-stream-clients/python/README.rst
@@ -50,14 +50,14 @@ Create a StreamClient instance with default parameters::
 
 Optional configurations that can be set (and their default values):
 
-- host: 'localhost'
-- port: 10000
-- namespace: default
-- ssl: False (set true to use HTTPS protocol)
-- ssl_cert_check: True (set False to suspend certificate checks; this allows self-signed
-  certificates when SSL is True)
-- authClient: null (`CDAP Authentication Client
-  <https://github.com/caskdata/cdap-clients/tree/develop/cdap-authentication-clients/python>`__)
+- ``host``: ``localhost``
+- ``port``: ``10000``
+- ``namespace``: ``default``
+- ``ssl``: ``False`` (set to ``True`` to use HTTPS protocol)
+- ``ssl_cert_check``: ``True`` (set to ``False`` to suspend certificate checks; this allows self-signed
+  certificates when SSL is ``True``)
+- ``authClient``: ``null`` (`CDAP Authentication Client
+  <https://github.com/caskdata/cdap-clients/tree/develop/cdap-authentication-clients/python>`__
   to interact with a secure CDAP instance)
 
 Example::
@@ -85,7 +85,7 @@ Create a new Stream with the ``stream-id`` *newStreamName*::
 
 Creating a StreamWriter
 -----------------------
-Create a ```StreamWriter``` instance for writing events to the Stream "streamName":
+Create a ``StreamWriter`` instance for writing events to the Stream *streamName*:
 
     stream_writer = stream_client.create_writer("streamName")
 
@@ -119,7 +119,7 @@ Get the current TTL value for the Stream *streamName*::
 
 StreamPromise
 -------------
-StreamPromise's goal is to implement deferred code execution.
+``StreamPromise``'s goal is to implement deferred code execution.
 
 For error handling, create a handler for each case and set it using the ``onResponse``
 method. The error handling callback function is optional.

--- a/cdap-stream-clients/python/README.rst
+++ b/cdap-stream-clients/python/README.rst
@@ -79,13 +79,13 @@ Example::
 
 Creating a Stream
 -----------------
-Create a new Stream with the ``stream-id`` *newStreamName*::
+Create a new Stream with the ``<stream-id>`` *newStreamName*::
 
     stream_client.create("newStreamName")
 
 **Notes:**
 
-- The ``stream-id`` should only contain ASCII letters, digits and hyphens.
+- The ``<stream-id>`` should only contain ASCII letters, digits and hyphens.
 - If the Stream already exists, no error is returned, and the existing Stream remains in place.
 
 Creating a StreamWriter

--- a/cdap-stream-clients/ruby/README.rst
+++ b/cdap-stream-clients/ruby/README.rst
@@ -37,7 +37,7 @@ If you use gem outside Rails, you should require gem files in your application f
 Example
 =======
 
-You can configure StreamClient settings in your config files, for example::
+You can configure ``StreamClient`` settings in your config files. For example::
 
   # config/stream.yml
   gateway: 'localhost'
@@ -69,7 +69,7 @@ If authentication is required, set authentication client::
   client.set_auth_client auth_client
 
 
-Create a new Stream with the *stream id* "new_stream_name"::
+Create a new Stream with the *stream-id* "new_stream_name"::
 
   client.create "new_stream_name"
 
@@ -130,17 +130,17 @@ All methods from the ``StreamClient`` and ``StreamWriter`` throw exceptions usin
 code analysis from the gateway server. These exceptions help determine if the request was
 processed successfully or not.
 
-In the case of a **200 OK** response, no exception will be thrown; other cases will throw
+In the case of a ``200 OK`` response, no exception will be thrown; other cases will throw
 these exceptions:
 
-- 400: 'The request had a combination of parameters that is not recognized'
-- 401: 'The request did not contain an authentication token'
-- 403: 'The request was authenticated but the client does not have permission'
-- 404: 'The request did not address any of the known URIs'
-- 405: 'A request was received with a method not supported for the URI'
-- 409: 'A request could not be completed due to a conflict with the current resource state'
-- 500: 'An internal error occurred while processing the request'
-- 501: 'A request contained a query that is not supported by this API'
+- ``400``: The request had a combination of parameters that is not recognized
+- ``401``: The request did not contain an authentication token
+- ``403``: The request was authenticated but the client does not have permission
+- ``404``: The request did not address any of the known URIs
+- ``405``: A request was received with a method not supported for the URI
+- ``409``: A request could not be completed due to a conflict with the current resource state
+- ``500``: An internal error occurred while processing the request
+- ``501``: A request contained a query that is not supported by this API
 
 
 Testing
@@ -151,19 +151,19 @@ To launch unit tests only, execute::
   rspec --tag ~it
 
 
-To launch integration tests against Standalone CDAP instance, execute::
+To launch integration tests against a Standalone CDAP instance, execute::
 
   rspec --tag type:it-local
 
 
-To launch integration tests against Standalone CDAP instance with authentication enabled,
+To launch integration tests against a Standalone CDAP instance with authentication enabled,
 execute::
 
   rspec --tag type:it-local-auth
 
 
-To launch integration tests against Standalone CDAP instance with authentication enabled
-and ssl turned on, execute::
+To launch integration tests against a Standalone CDAP instance with authentication enabled
+and SSL turned on, execute::
 
   rspec --tag type:it-local-auth-ssl
 

--- a/cdap-stream-clients/ruby/README.rst
+++ b/cdap-stream-clients/ruby/README.rst
@@ -1,3 +1,8 @@
+.. meta::
+    :author: Cask Data, Inc.
+    :copyright: Copyright © 2015 Cask Data, Inc.
+    :license: See LICENSE file in this repository
+
 ===========================
 CDAP Stream Client for Ruby
 ===========================
@@ -166,23 +171,3 @@ To launch integration tests against a Standalone CDAP instance with authenticati
 and SSL turned on, execute::
 
   rspec --tag type:it-local-auth-ssl
-
-
-License and Trademarks
-----------------------
-Copyright © 2014-2015 Cask Data, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-in compliance with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the
-License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied. See the License for the specific language governing permissions
-and limitations under the License.
-
-Cask is a trademark of Cask Data, Inc. All rights reserved.
-
-Apache, Apache HBase, and HBase are trademarks of The Apache Software Foundation. Used with
-permission. No endorsement by The Apache Software Foundation is implied by the use of these marks.

--- a/cdap-stream-clients/ruby/README.rst
+++ b/cdap-stream-clients/ruby/README.rst
@@ -1,6 +1,6 @@
 .. meta::
     :author: Cask Data, Inc.
-    :copyright: Copyright © 2015 Cask Data, Inc.
+    :copyright: Copyright © 2014-2015 Cask Data, Inc.
     :license: See LICENSE file in this repository
 
 ===========================

--- a/cdap-stream-clients/ruby/README.rst
+++ b/cdap-stream-clients/ruby/README.rst
@@ -74,14 +74,14 @@ If authentication is required, set authentication client::
   client.set_auth_client auth_client
 
 
-Create a new Stream with the *stream-id* "new_stream_name"::
+Create a new Stream with the ``<stream-id>`` *new_stream_name*::
 
   client.create "new_stream_name"
 
 
 Notes:
 
-- The <stream-id> must only contain ASCII letters, digits and hyphens.
+- The ``<stream-id>`` must only contain ASCII letters, digits and hyphens.
 - If the Stream already exists, no error is returned, and the existing Stream remains in place.
 
 


### PR DESCRIPTION
Fixes, tweaks, corrections, adjustments. Each file has the same copyright statement at the end. When the file is included elsewhere, the include will stop before it.
