### PR TITLE
Add codeclimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,30 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+      - javascript
+      - python
+      - php
+  eslint:
+    enabled: true
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.py"
+  - "**.rb"
+exclude_paths:
+- cdap-stream-clients/*/test/
+- cdap-stream-clients/*/spec/


### PR DESCRIPTION
This is the default configuration other than excluding testing our tests. Tests commonly have duplicated code and other such things that we want to fix in the main codebase, but aren't very concerned about in tests.

<img width="964" alt="screen shot 2016-10-12 at 5 04 25 pm" src="https://cloud.githubusercontent.com/assets/380021/19327656/ff9eaf00-909d-11e6-943b-bd901b4a012c.png">
